### PR TITLE
Remove Readme.md which is identical to README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,0 @@
-Getting started
----------------
-
-* Install [node.js](http://nodejs.org/download/)
-* Install the node.js dependencies: `npm install`
-* Run `node make` or `node make minify`
-
-You can run `npm run lint` to run [JSHint](https://github.com/jshint/jshint)
-and [csslint](https://github.com/stubbornella/csslint) for our files.

--- a/upload.sh
+++ b/upload.sh
@@ -9,7 +9,6 @@ rm .gitattributes
 rm .gitignore
 rm LICENSE
 rm README.md
-rm Readme.md
 rm upload.sh
 
 scp -r . $1,cppcheck@web.sf.net:htdocs/


### PR DESCRIPTION
The filenames also differ only by upper/lower case, so the names collide
on a case-insensitive filesystem, such as NTFS.

Disclaimer: I did no research on why there are two files in the first place, and whether removing one breaks something.