### PR TITLE
Adding Codety into the cppcheck-htdocs index tool list

### DIFF
--- a/index.php
+++ b/index.php
@@ -218,7 +218,7 @@ This has been described in a few articles (<a href="https://www.theregister.co.u
   <li><strong>CppDepend 5</strong> - <a href="http://www.cppdepend.com/CppDependV5.aspx">integrated</a></li>
   <li><strong>Eclipse</strong> - <a href="https://github.com/cppchecksolutions/cppcheclipse/wiki/Installation">Cppcheclipse</a></li>
   <li><strong>gedit</strong> - <a href="http://github.com/odamite/gedit-cppcheck">gedit plugin</a></li>
-  <li><strong>github</strong> - <a href="https://www.codacy.com/">Codacy</a> and <a href="http://www.softacheck.com/">SoftaCheck</a></li>
+  <li><strong>github</strong> - <a href="https://www.codacy.com/">Codacy</a>, <a href="https://www.codety.io/">Codety</a> and <a href="http://www.softacheck.com/">SoftaCheck</a></li>
   <li><strong>Hudson</strong> - <a href="http://wiki.hudson-ci.org/display/HUDSON/Cppcheck+Plugin">Cppcheck Plugin</a></li>
   <li><strong>Jenkins</strong> - <a href="http://wiki.jenkins-ci.org/display/JENKINS/Cppcheck+Plugin">Cppcheck Plugin</a></li>
   <li><strong>KDevelop</strong> - <a href="https://kdevelop.org/">integrated since v5.1</a></li>


### PR DESCRIPTION
Add Codety into the tool list as Codety Scanner uses cppcheck as C&C++ code analyzer, Codety Scanner provides out-of-box cppcheck integration for automating the code reviews. 
Here're some examples of Codety Scanner's github integration:
* GitHub pull request comments (https://github.com/codetyio/codety-scanner/pull/15#issuecomment-2320351633)
* GitHub pull request review comments ([check example here](https://github.com/codetyio/codety-scanner/pull/15/files#r1738123885))
* GitHub check run annotations ([check example here](https://github.com/codetyio/codety-scanner/actions/runs/10786005219/job/29912189435))


Codety also added cppcheck into the credits list: https://github.com/codetyio/codety-scanner/blob/main/CREDITS.md

This is Codety Scanner's git repo: https://github.com/codetyio/codety-scanner